### PR TITLE
Add `jsnext:main` to package.json, for ease of use by es6 bundlers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "Wrap your component up as a custom element",
   "main": "dist/bundle.js",
+  "jsnext:main": "src/index.js",
   "scripts": {
     "test": "npm test"
   },


### PR DESCRIPTION
Considered adding the `module` field as well, but preact doesn't use it, so I left it out.

Ties to https://github.com/bspaulding/preact-custom-element/issues/5.