### PR TITLE
Fix #4 - Updating to custom elements v1

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1,1 +1,195 @@
-!function(e,t){if("object"==typeof exports&&"object"==typeof module)module.exports=t(require("preact"));else if("function"==typeof define&&define.amd)define(["preact"],t);else{var o=t("object"==typeof exports?require("preact"):e.preact);for(var r in o)("object"==typeof exports?exports:e)[r]=o[r]}}(this,function(e){return function(e){function t(r){if(o[r])return o[r].exports;var n=o[r]={exports:{},id:r,loaded:!1};return e[r].call(n.exports,n,n.exports,t),n.loaded=!0,n.exports}var o={};return t.m=e,t.c=o,t.p="",t(0)}([function(e,t,o){"use strict";function r(e,t){var o=Object.create(HTMLElement.prototype);return o._vdomComponent=e,o.attachedCallback=o.attributeChangedCallback=n,o.detachedCallback=a,document.registerElement(t||e.displayName||e.name,{prototype:o})}function n(){this._root=(0,u.render)(i(this,this._vdomComponent),this.shadowRoot||this.createShadowRoot(),this._root)}function a(){(0,u.render)((0,u.h)(c),this.shadowRoot,this._root)}function i(e,t){if(3===e.nodeType)return e.nodeValue;if(1!==e.nodeType)return null;var o=[],r={},n=0,a=e.attributes,c=e.childNodes;for(n=a.length;n--;)r[a[n].name]=a[n].value;for(n=c.length;n--;)o[n]=i(c[n]);return(0,u.h)(t||e.nodeName.toLowerCase(),r,o)}Object.defineProperty(t,"__esModule",{value:!0}),t["default"]=r;var u=o(1),c=function(){return null}},function(t,o){t.exports=e}])});
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory(require("preact"));
+	else if(typeof define === 'function' && define.amd)
+		define(["preact"], factory);
+	else {
+		var a = typeof exports === 'object' ? factory(require("preact")) : factory(root["preact"]);
+		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];
+	}
+})(this, function(__WEBPACK_EXTERNAL_MODULE_1__) {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
+
+	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+	exports.default = register;
+
+	var _preact = __webpack_require__(1);
+
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+	var Empty = function Empty() {
+		return null;
+	};
+
+	function toVdom(element, nodeName) {
+		if (element.nodeType === 3) return element.nodeValue;
+		if (element.nodeType !== 1) return null;
+		var children = [],
+		    props = {};
+		var _iteratorNormalCompletion = true;
+		var _didIteratorError = false;
+		var _iteratorError = undefined;
+
+		try {
+			for (var _iterator = element.attributes[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+				var att = _step.value;
+
+				props[att.name] = att.value;
+			}
+		} catch (err) {
+			_didIteratorError = true;
+			_iteratorError = err;
+		} finally {
+			try {
+				if (!_iteratorNormalCompletion && _iterator.return) {
+					_iterator.return();
+				}
+			} finally {
+				if (_didIteratorError) {
+					throw _iteratorError;
+				}
+			}
+		}
+
+		var _iteratorNormalCompletion2 = true;
+		var _didIteratorError2 = false;
+		var _iteratorError2 = undefined;
+
+		try {
+			for (var _iterator2 = element.childNodes[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+				var child = _step2.value;
+
+				children.push(this.toVdom(child));
+			}
+		} catch (err) {
+			_didIteratorError2 = true;
+			_iteratorError2 = err;
+		} finally {
+			try {
+				if (!_iteratorNormalCompletion2 && _iterator2.return) {
+					_iterator2.return();
+				}
+			} finally {
+				if (_didIteratorError2) {
+					throw _iteratorError2;
+				}
+			}
+		}
+
+		return (0, _preact.h)(nodeName || element.nodeName.toLowerCase(), props, children);
+	}
+
+	function wrapPreactComponent(Component, tagName) {
+		return function (_HTMLElement) {
+			_inherits(_class, _HTMLElement);
+
+			function _class() {
+				_classCallCheck(this, _class);
+
+				var _this = _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).call(this));
+
+				_this.shadowRoot = _this.attachShadow({ mode: 'open' });
+				_this._vdomComponent = Component;
+				return _this;
+			}
+
+			_createClass(_class, [{
+				key: 'connectedCallback',
+				value: function connectedCallback() {
+					this.renderElement();
+				}
+			}, {
+				key: 'attributeChangedCallback',
+				value: function attributeChangedCallback(attrName, oldVal, newVal) {
+					this.renderElement();
+				}
+			}, {
+				key: 'disconnectedCallback',
+				value: function disconnectedCallback() {
+					this.unRenderElement();
+				}
+			}, {
+				key: 'renderElement',
+				value: function renderElement() {
+					(0, _preact.render)(toVdom(this, this._vdomComponent), this.shadowRoot, this._root);
+				}
+			}, {
+				key: 'unrenderElement',
+				value: function unrenderElement() {
+					(0, _preact.render)((0, _preact.h)(Empty), this.shadowRoot, this._root);
+				}
+			}]);
+
+			return _class;
+		}(HTMLElement);
+	}
+
+	function register(Component, tagName) {
+		return window.customElements.define(tagName || Component.displayName || Component.name, wrapPreactComponent(Component, tagName));
+	}
+
+/***/ },
+/* 1 */
+/***/ function(module, exports) {
+
+	module.exports = __WEBPACK_EXTERNAL_MODULE_1__;
+
+/***/ }
+/******/ ])
+});
+;

--- a/src/index.js
+++ b/src/index.js
@@ -2,34 +2,54 @@ import { h, render } from 'preact';
 
 const Empty = () => null;
 
-export default function register(Component, tagName) {
-	let prototype = Object.create(HTMLElement.prototype);
-	prototype._vdomComponent = Component;
-	prototype.attachedCallback = prototype.attributeChangedCallback = renderElement;
-	prototype.detachedCallback = unRenderElement;
-	return document.registerElement(
-		tagName || Component.displayName || Component.name,
-		{ prototype }
-	);
-}
-
-function renderElement() {
-	this._root = render(
-		toVdom(this, this._vdomComponent),
-		this.shadowRoot || this.createShadowRoot(),
-		this._root
-	);
-}
-
-function unRenderElement() {
-	render(h(Empty), this.shadowRoot, this._root);
-}
-
 function toVdom(element, nodeName) {
 	if (element.nodeType===3) return element.nodeValue;
 	if (element.nodeType!==1) return null;
-	let children=[], props={}, i=0, a=element.attributes, cn=element.childNodes;
-	for (i=a.length; i--; ) props[a[i].name] = a[i].value;
-	for (i=cn.length; i--; ) children[i] = toVdom(cn[i]);
+	let children=[], props={};
+	for (let att of element.attributes) { 
+		props[att.name] = att.value;
+	}
+	for (let child of element.childNodes) { 
+		children.push(this.toVdom(child));
+	}
 	return h(nodeName || element.nodeName.toLowerCase(), props, children);
+}
+
+
+function wrapPreactComponent(Component, tagName) {
+	return class extends HTMLElement {
+		constructor() {
+			super();
+			this.shadowRoot = this.attachShadow({mode: 'open'});
+			this._vdomComponent = Component;
+		}
+	
+		connectedCallback()  {
+			this.renderElement();
+		}
+	
+		attributeChangedCallback(attrName, oldVal, newVal)  {
+			this.renderElement();
+		}
+	
+		disconnectedCallback() {
+			this.unRenderElement();
+		}
+	
+	
+		renderElement() {
+			render(toVdom(this, this._vdomComponent), this.shadowRoot, this._root);			
+		}
+	
+		unrenderElement() {
+			render(h(Empty), this.shadowRoot, this._root);
+		}
+	}
+}
+
+export default function register(Component, tagName) {
+	return window.customElements.define(
+		tagName || Component.displayName || Component.name,
+		wrapPreactComponent(Component, tagName)
+	);
 }


### PR DESCRIPTION
I needed a Custom Elements V1 implementation, I used @0xR 's version in #4  as base to do a es6 class-based implementation. 

As @0xR said, when transpiling to es5, you need [native-shim.js](https://github.com/webcomponents/custom-elements/blob/master/src/native-shim.js) (see [here](https://github.com/webcomponents/custom-elements#es5-vs-es2015) for more explanations). 

About @bspaulding three questions : 

> 1. What's support look like for v1?

According to [Can I use?](https://caniuse.com/#feat=custom-elementsv1) the support of v1 shines now: Chrome and Safari already have it, Firefox will have it in next version (Firefox 59). And for current and old Firefox, Edge or old Safari and Chrome, you have the polyfill.

The support of V0 is way poorer, only Chrome implements if, and you can use an old polyfill to make it work in other browsers. And even Chrome will drop the support, as it's an outdated spec.

> 2. How can we supply versions compatible with v0 and v1 and let the user decide which they require?

Well, I think you could offer two versions of the packager... or, wait a second (I'm thinking while I write...),  two exports! One for v0 and another for v1!

But I am not sure if it would be useful...

> 3. As a consumer, what's exceptional about v1 that I would require it over v0?

Well, V1 is already way better supported either natively on Chrome, Safari and soon Firefox or with a faster and leaner polyfill in other browsers.


I'm putting a PR on this, and if you want I can try to put the two exports version, that could allow you to support both v1 and v2.

What do you think ?


*Note: I am not sure how you generate the bundle, I have used `npx webpack` but it generates me a umd module bigger than your bundle. Feel free to overwrite it, and please tell me how to generate the right bundle*